### PR TITLE
Add legacy player data retrieval and display

### DIFF
--- a/Backend/RetroRewindWebsite/Controllers/LeaderboardController.cs
+++ b/Backend/RetroRewindWebsite/Controllers/LeaderboardController.cs
@@ -362,5 +362,32 @@ namespace RetroRewindWebsite.Controllers
                 return StatusCode(500, "An error occurred while retrieving Mii images");
             }
         }
+
+        [HttpGet("legacy/player/{friendCode}")]
+        public async Task<ActionResult<PlayerDto>> GetLegacyPlayer(string friendCode)
+        {
+            try
+            {
+                var hasSnapshot = await _leaderboardManager.HasLegacySnapshotAsync();
+                if (!hasSnapshot)
+                {
+                    return NotFound("Legacy leaderboard snapshot not available");
+                }
+
+                var legacyPlayer = await _leaderboardManager.GetLegacyPlayerAsync(friendCode);
+
+                if (legacyPlayer == null)
+                {
+                    return NotFound($"Player with friend code {friendCode} not found in legacy snapshot");
+                }
+
+                return Ok(legacyPlayer);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting legacy player data for friend code {friendCode}", friendCode);
+                return StatusCode(500, "An error occurred while retrieving legacy player data");
+            }
+        }
     }
 }

--- a/Backend/RetroRewindWebsite/Repositories/IPlayerRepository.cs
+++ b/Backend/RetroRewindWebsite/Repositories/IPlayerRepository.cs
@@ -44,5 +44,6 @@ namespace RetroRewindWebsite.Repositories
         Task<int> GetLegacyPlayersCountAsync();
         Task<int> GetLegacySuspiciousPlayersCountAsync();
         Task<List<LegacyPlayerEntity>> GetLegacyPlayersByFriendCodesAsync(List<string> friendCodes);
+        Task<LegacyPlayerEntity?> GetLegacyPlayerByFriendCodeAsync(string friendCode);
     }
 }

--- a/Backend/RetroRewindWebsite/Repositories/PlayerRepository.cs
+++ b/Backend/RetroRewindWebsite/Repositories/PlayerRepository.cs
@@ -455,5 +455,12 @@ namespace RetroRewindWebsite.Repositories
                 .Where(p => normalizedCodes.Contains(p.Fc.Replace("-", "")))
                 .ToListAsync();
         }
+
+        public async Task<LegacyPlayerEntity?> GetLegacyPlayerByFriendCodeAsync(string friendCode)
+        {
+            return await _context.LegacyPlayers
+                .AsNoTracking()
+                .FirstOrDefaultAsync(p => p.Fc == friendCode);
+        }
     }
 }

--- a/Backend/RetroRewindWebsite/Services/Application/ILeaderboardManager.cs
+++ b/Backend/RetroRewindWebsite/Services/Application/ILeaderboardManager.cs
@@ -15,5 +15,6 @@ namespace RetroRewindWebsite.Services.Application
         Task<bool> HasLegacySnapshotAsync();
         Task<LeaderboardResponseDto> GetLegacyLeaderboardAsync(LeaderboardRequest request);
         Task<Dictionary<string, string?>> GetLegacyPlayerMiisBatchAsync(List<string> friendCodes);
+        Task<PlayerDto?> GetLegacyPlayerAsync(string friendCode);
     }
 }

--- a/Backend/RetroRewindWebsite/Services/Application/LeaderboardManager.cs
+++ b/Backend/RetroRewindWebsite/Services/Application/LeaderboardManager.cs
@@ -547,5 +547,46 @@ namespace RetroRewindWebsite.Services.Application
 
             return result;
         }
+
+        public async Task<PlayerDto?> GetLegacyPlayerAsync(string friendCode)
+        {
+            var legacyPlayer = await _playerRepository.GetLegacyPlayerByFriendCodeAsync(friendCode);
+
+            if (legacyPlayer == null)
+            {
+                return null;
+            }
+
+            // Get Mii image
+            string? miiImage = null;
+            try
+            {
+                miiImage = await _miiService.GetMiiImageAsync(legacyPlayer.Fc, legacyPlayer.MiiData);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to get Mii image for legacy player {fc}", legacyPlayer.Fc);
+            }
+
+            return new PlayerDto
+            {
+                Pid = legacyPlayer.Pid,
+                Name = legacyPlayer.Name,
+                FriendCode = legacyPlayer.Fc,
+                VR = legacyPlayer.Ev,
+                Rank = legacyPlayer.Rank,
+                ActiveRank = null,
+                LastSeen = legacyPlayer.SnapshotDate,
+                IsActive = true,
+                IsSuspicious = legacyPlayer.IsSuspicious,
+                VRStats = new VRStatsDto
+                {
+                    Last24Hours = 0,
+                    LastWeek = 0,
+                    LastMonth = 0
+                },
+                MiiImageBase64 = miiImage
+            };
+        }
     }
 }

--- a/Frontend/src/hooks/usePlayer.tsx
+++ b/Frontend/src/hooks/usePlayer.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/solid-query";
 import { api } from "../services/api";
+import { createMemo } from "solid-js";
 
 export function usePlayer(friendCode: string) {
     const playerQuery = useQuery(() => ({
@@ -8,6 +9,19 @@ export function usePlayer(friendCode: string) {
         refetchInterval: 60000,
     }));
 
+    // Query for legacy player data
+    const legacyPlayerQuery = useQuery(() => ({
+        queryKey: ["legacyPlayer", friendCode],
+        queryFn: () => api.getLegacyPlayer(friendCode),
+        retry: false, // Don't retry on failure
+        refetchInterval: false, // Legacy data never changes
+        enabled: playerQuery.isSuccess, // Only fetch if current player exists
+    }));
+
+    // CreateMemo to make reactive
+    const legacyPlayer = createMemo(() => legacyPlayerQuery.data);
+    const hasLegacyData = createMemo(() => legacyPlayerQuery.isSuccess);
+
     return {
         playerQuery,
         player: playerQuery.data,
@@ -15,5 +29,10 @@ export function usePlayer(friendCode: string) {
         isError: playerQuery.isError,
         error: playerQuery.error,
         refetch: playerQuery.refetch,
+        
+        // Legacy data
+        legacyPlayerQuery,
+        legacyPlayer,
+        hasLegacyData,
     };
 }

--- a/Frontend/src/pages/Downloads/DownloadsPage.tsx
+++ b/Frontend/src/pages/Downloads/DownloadsPage.tsx
@@ -19,7 +19,7 @@ export default function DownloadsPage() {
                     <div class="text-2xl">📦</div>
                     <div class="flex-1">
                         <h2 class="text-2xl font-bold text-blue-900 dark:text-blue-100 mb-2">
-                            Retro Rewind v6.4.2
+                            Retro Rewind v6.5
                         </h2>
                         <p class="text-lg text-blue-800 dark:text-blue-200 mb-4">
                             Complete distribution with 184 retro tracks and 80 custom tracks
@@ -34,12 +34,12 @@ export default function DownloadsPage() {
                                 Full Download (First Install)
                             </a>
                             <a
-                                href="http://update.rwfc.net:8000/RetroRewind/zip/6.4.2.zip"
+                                href="http://update.rwfc.net:8000/RetroRewind/zip/6.5.zip"
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 class="bg-blue-700 hover:bg-blue-800 text-white font-semibold py-3 px-6 rounded-lg transition-colors text-center"
                             >
-                                Update Only (v6.4 → v6.4.2)
+                                Update Only (v6.4.2 → v6.5)
                             </a>
                         </div>
                     </div>

--- a/Frontend/src/pages/Player/PlayerDetailPage.tsx
+++ b/Frontend/src/pages/Player/PlayerDetailPage.tsx
@@ -11,7 +11,11 @@ import {
 
 export default function PlayerDetailPage() {
     const params = useParams();
-    const { playerQuery } = usePlayer(params.friendCode);
+    const { 
+        playerQuery, 
+        legacyPlayer, 
+        hasLegacyData 
+    } = usePlayer(params.friendCode);
 
     // Check if player was not found (404 error)
     const isPlayerNotFound = () => {
@@ -183,14 +187,31 @@ export default function PlayerDetailPage() {
                                     </div>
                                 </div>
 
-                                {/* VR Display */}
+                                {/* VR Display - Current and Legacy */}
                                 <div class="text-center">
                                     <div class="text-5xl font-bold text-blue-600 dark:text-blue-400 mb-1">
                                         {player().vr.toLocaleString()}
                                     </div>
-                                    <div class="text-lg text-gray-600 dark:text-gray-400 font-medium">
-                                        VR
+                                    <div class="text-lg text-gray-600 dark:text-gray-400 font-medium mb-3">
+                                        Current VR
                                     </div>
+                                    
+                                    {/* Legacy VR Display */}
+                                    <Show when={hasLegacyData() && legacyPlayer()}>
+                                        {(legacy) => (
+                                            <div class="pt-3 border-t-2 border-gray-200 dark:border-gray-700">
+                                                <div class="flex items-center justify-center gap-2 mb-1">
+                                                    <span class="text-xl">🏆</span>
+                                                    <div class="text-2xl font-bold text-amber-600 dark:text-amber-400">
+                                                        {legacy().vr.toLocaleString()}
+                                                    </div>
+                                                </div>
+                                                <div class="text-sm text-gray-500 dark:text-gray-500 font-medium">
+                                                    Legacy VR (#{legacy().rank})
+                                                </div>
+                                            </div>
+                                        )}
+                                    </Show>
                                 </div>
                             </div>
                         </div>
@@ -283,6 +304,30 @@ export default function PlayerDetailPage() {
                                                 {player().vr.toLocaleString()}
                                             </span>
                                         </div>
+                                        
+                                        {/* Legacy Rank in Summary */}
+                                        <Show when={hasLegacyData() && legacyPlayer()}>
+                                            {(legacy) => (
+                                                <>
+                                                    <div class="flex justify-between pt-2 border-t border-gray-200 dark:border-gray-700">
+                                                        <span class="text-gray-600 dark:text-gray-400">
+                                                            🏆 Legacy Rank:
+                                                        </span>
+                                                        <span class="font-medium text-amber-600 dark:text-amber-400">
+                                                            #{legacy().rank}
+                                                        </span>
+                                                    </div>
+                                                    <div class="flex justify-between">
+                                                        <span class="text-gray-600 dark:text-gray-400">
+                                                            🏆 Legacy VR:
+                                                        </span>
+                                                        <span class="font-medium text-amber-600 dark:text-amber-400">
+                                                            {legacy().vr.toLocaleString()}
+                                                        </span>
+                                                    </div>
+                                                </>
+                                            )}
+                                        </Show>
                                     </div>
                                 </div>
 

--- a/Frontend/src/services/api/leaderboard.ts
+++ b/Frontend/src/services/api/leaderboard.ts
@@ -59,6 +59,10 @@ export const leaderboardApi = {
         return apiRequest<Player>(`/leaderboard/player/${friendCode}`);
     },
 
+    async getLegacyPlayer(friendCode: string): Promise<Player> {
+        return apiRequest<Player>(`/leaderboard/legacy/player/${friendCode}`);
+    },
+
     async getStats(): Promise<LeaderboardStats> {
         return apiRequest<LeaderboardStats>("/leaderboard/stats");
     },
@@ -207,3 +211,4 @@ export const legacyLeaderboardApi = {
         return { miis: allMiis };
     },
 };
+


### PR DESCRIPTION
Introduces backend endpoints and repository methods to fetch legacy player data by friend code, along with corresponding service logic. Updates frontend hooks and PlayerDetailPage to query and display legacy VR and rank for players, and updates download links to v6.5.