### PR TITLE
Fix type error in LeaderboardPlayerDetailPage

### DIFF
--- a/Frontend/src/pages/Leaderboard/LeaderboardPlayerDetailPage.tsx
+++ b/Frontend/src/pages/Leaderboard/LeaderboardPlayerDetailPage.tsx
@@ -24,7 +24,7 @@ import { LoadingSpinner } from "../../components/common";
 export default function PlayerDetailPage() {
     const params = useParams();
     const { playerQuery, legacyPlayer, hasLegacyData, isPlayerNotFound } =
-    usePlayer(params.friendCode);
+    usePlayer(params.friendCode ?? "0000-0000-0000");
 
     return (
         <div class="space-y-6">


### PR DESCRIPTION
Compilation fails here. Just set to default "0000-0000-0000" so it ends up displaying not found.