### PR TITLE
Add engineClass filter to player race stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Normalize all text files to LF on commit and checkout
-* text=auto eol=lf
+# Normalize line endings in the repository to LF; working tree uses platform default (CRLF on Windows)
+* text=auto
 
 # Explicitly mark binary files as binary (no line ending conversion)
 *.png binary

--- a/Backend/RetroRewindWebsite/Controllers/RaceStatsController.cs
+++ b/Backend/RetroRewindWebsite/Controllers/RaceStatsController.cs
@@ -32,6 +32,7 @@ public class RaceStatsController : ControllerBase
         string pid,
         [FromQuery] int? days = null,
         [FromQuery] short? courseId = null,
+        [FromQuery] short? engineClassId = null,
         [FromQuery] int page = 1,
         [FromQuery] int pageSize = DefaultPageSize)
     {
@@ -40,7 +41,7 @@ public class RaceStatsController : ControllerBase
             page = Math.Max(1, page);
             pageSize = Math.Clamp(pageSize, MinPageSize, MaxPageSize);
 
-            var stats = await _raceStatsService.GetPlayerRaceStatsAsync(pid, days, courseId, page, pageSize);
+            var stats = await _raceStatsService.GetPlayerRaceStatsAsync(pid, days, courseId, engineClassId, page, pageSize);
             if (stats == null)
                 return NotFound($"No race data found for player '{pid}'");
 

--- a/Backend/RetroRewindWebsite/Repositories/RaceResult/IRaceStatsRepository.cs
+++ b/Backend/RetroRewindWebsite/Repositories/RaceResult/IRaceStatsRepository.cs
@@ -16,7 +16,7 @@ public interface IRaceStatsRepository
     /// considered.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the total number of races matching
     /// the specified criteria.</returns>
-    Task<int> GetTotalRaceCountByPlayerAsync(long profileId, DateTime? after, short? courseId);
+    Task<int> GetTotalRaceCountByPlayerAsync(long profileId, DateTime? after, short? courseId, short? engineClassId = null);
 
     /// <summary>
     /// Asynchronously retrieves the timestamp of the earliest recorded race, if available.
@@ -38,7 +38,7 @@ public interface IRaceStatsRepository
     /// <returns>A task that represents the asynchronous operation. The task result contains a list of tuples, each consisting of
     /// a course ID and the corresponding play count, ordered by play count in descending order. The list contains at
     /// most the specified number of items.</returns>
-    Task<List<(short CourseId, int Count)>> GetTopTracksByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId);
+    Task<List<(short CourseId, int Count)>> GetTopTracksByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId, short? engineClassId = null);
 
     /// <summary>
     /// Asynchronously retrieves the top characters used by a player, ranked by usage count.
@@ -52,7 +52,7 @@ public interface IRaceStatsRepository
     /// <returns>A task that represents the asynchronous operation. The task result contains a list of tuples, each consisting of
     /// a character ID and the corresponding usage count, ordered by count in descending order. The list may be empty if
     /// no usage data is found.</returns>
-    Task<List<(short Id, int Count)>> GetTopCharactersByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId);
+    Task<List<(short Id, int Count)>> GetTopCharactersByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId, short? engineClassId = null);
 
     /// <summary>
     /// Asynchronously retrieves the top vehicles used by a specific player, ranked by usage count.
@@ -66,7 +66,7 @@ public interface IRaceStatsRepository
     /// <returns>A task that represents the asynchronous operation. The task result contains a list of tuples, each consisting of
     /// a vehicle ID and its corresponding usage count, ordered by count in descending order. The list may be empty if
     /// no usage data is found.</returns>
-    Task<List<(short Id, int Count)>> GetTopVehiclesByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId);
+    Task<List<(short Id, int Count)>> GetTopVehiclesByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId, short? engineClassId = null);
 
     /// <summary>
     /// Asynchronously retrieves the most frequently used character and vehicle combinations for a specified player
@@ -81,7 +81,7 @@ public interface IRaceStatsRepository
     /// <returns>A task that represents the asynchronous operation. The task result contains a list of tuples, each consisting of
     /// a character ID, vehicle ID, and the count of times that combination was used, ordered by descending count. The
     /// list may be empty if no data matches the criteria.</returns>
-    Task<List<(short CharacterId, short VehicleId, int Count)>> GetTopCombosByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId);
+    Task<List<(short CharacterId, short VehicleId, int Count)>> GetTopCombosByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId, short? engineClassId = null);
 
     /// <summary>
     /// Asynchronously retrieves the total number of frames in which the specified player finished in first place,
@@ -93,7 +93,7 @@ public interface IRaceStatsRepository
     /// <param name="courseId">An optional course identifier. If specified, only results from this course are included.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the total number of first-place
     /// frames for the specified player, filtered as requested.</returns>
-    Task<long> GetTotalFramesIn1stByPlayerAsync(long profileId, DateTime? after, short? courseId);
+    Task<long> GetTotalFramesIn1stByPlayerAsync(long profileId, DateTime? after, short? courseId, short? engineClassId = null);
 
     /// <summary>
     /// Asynchronously retrieves a paginated list of recent race results for a specified player profile, optionally
@@ -108,7 +108,7 @@ public interface IRaceStatsRepository
     /// included.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a tuple with a list of recent race
     /// results and the total count of matching races.</returns>
-    Task<(List<RaceResultEntity> Rows, int TotalCount)> GetRecentRacesByPlayerAsync(long profileId, int page, int pageSize, DateTime? after, short? courseId);
+    Task<(List<RaceResultEntity> Rows, int TotalCount)> GetRecentRacesByPlayerAsync(long profileId, int page, int pageSize, DateTime? after, short? courseId, short? engineClassId = null);
 
     // ===== GLOBAL =====
 

--- a/Backend/RetroRewindWebsite/Repositories/RaceResult/RaceStatsRepository.cs
+++ b/Backend/RetroRewindWebsite/Repositories/RaceResult/RaceStatsRepository.cs
@@ -15,7 +15,7 @@ public class RaceStatsRepository : IRaceStatsRepository
 
     // ===== HELPERS =====
 
-    private IQueryable<RaceResultEntity> BasePlayerQuery(long profileId, DateTime? after, short? courseId)
+    private IQueryable<RaceResultEntity> BasePlayerQuery(long profileId, DateTime? after, short? courseId, short? engineClassId)
     {
         var query = _context.RaceResults
             .AsNoTracking()
@@ -26,6 +26,9 @@ public class RaceStatsRepository : IRaceStatsRepository
 
         if (courseId.HasValue)
             query = query.Where(r => r.CourseId == courseId.Value);
+
+        if (engineClassId.HasValue)
+            query = query.Where(r => r.EngineClassId == engineClassId.Value);
 
         return query;
     }
@@ -42,17 +45,17 @@ public class RaceStatsRepository : IRaceStatsRepository
 
     // ===== PLAYER =====
 
-    public async Task<int> GetTotalRaceCountByPlayerAsync(long profileId, DateTime? after, short? courseId) =>
-        await BasePlayerQuery(profileId, after, courseId).CountAsync();
+    public async Task<int> GetTotalRaceCountByPlayerAsync(long profileId, DateTime? after, short? courseId, short? engineClassId = null) =>
+        await BasePlayerQuery(profileId, after, courseId, engineClassId).CountAsync();
 
     public async Task<DateTime?> GetEarliestRaceTimestampAsync() =>
         await _context.RaceResults
             .AsNoTracking()
             .MinAsync(r => (DateTime?)r.RaceTimestamp);
 
-    public async Task<List<(short CourseId, int Count)>> GetTopTracksByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId)
+    public async Task<List<(short CourseId, int Count)>> GetTopTracksByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId, short? engineClassId = null)
     {
-        var rows = await BasePlayerQuery(profileId, after, courseId)
+        var rows = await BasePlayerQuery(profileId, after, courseId, engineClassId)
             .GroupBy(r => r.CourseId)
             .Select(g => new { CourseId = g.Key, Count = g.Count() })
             .OrderByDescending(x => x.Count)
@@ -62,9 +65,9 @@ public class RaceStatsRepository : IRaceStatsRepository
         return [.. rows.Select(x => (x.CourseId, x.Count))];
     }
 
-    public async Task<List<(short Id, int Count)>> GetTopCharactersByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId)
+    public async Task<List<(short Id, int Count)>> GetTopCharactersByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId, short? engineClassId = null)
     {
-        var rows = await BasePlayerQuery(profileId, after, courseId)
+        var rows = await BasePlayerQuery(profileId, after, courseId, engineClassId)
             .GroupBy(r => r.CharacterId)
             .Select(g => new { Id = g.Key, Count = g.Count() })
             .OrderByDescending(x => x.Count)
@@ -74,9 +77,9 @@ public class RaceStatsRepository : IRaceStatsRepository
         return [.. rows.Select(x => (x.Id, x.Count))];
     }
 
-    public async Task<List<(short Id, int Count)>> GetTopVehiclesByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId)
+    public async Task<List<(short Id, int Count)>> GetTopVehiclesByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId, short? engineClassId = null)
     {
-        var rows = await BasePlayerQuery(profileId, after, courseId)
+        var rows = await BasePlayerQuery(profileId, after, courseId, engineClassId)
             .GroupBy(r => r.VehicleId)
             .Select(g => new { Id = g.Key, Count = g.Count() })
             .OrderByDescending(x => x.Count)
@@ -86,9 +89,9 @@ public class RaceStatsRepository : IRaceStatsRepository
         return [.. rows.Select(x => (x.Id, x.Count))];
     }
 
-    public async Task<List<(short CharacterId, short VehicleId, int Count)>> GetTopCombosByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId)
+    public async Task<List<(short CharacterId, short VehicleId, int Count)>> GetTopCombosByPlayerAsync(long profileId, int limit, DateTime? after, short? courseId, short? engineClassId = null)
     {
-        var rows = await BasePlayerQuery(profileId, after, courseId)
+        var rows = await BasePlayerQuery(profileId, after, courseId, engineClassId)
             .GroupBy(r => new { r.CharacterId, r.VehicleId })
             .Select(g => new { g.Key.CharacterId, g.Key.VehicleId, Count = g.Count() })
             .OrderByDescending(x => x.Count)
@@ -98,14 +101,14 @@ public class RaceStatsRepository : IRaceStatsRepository
         return [.. rows.Select(x => (x.CharacterId, x.VehicleId, x.Count))];
     }
 
-    public async Task<long> GetTotalFramesIn1stByPlayerAsync(long profileId, DateTime? after, short? courseId) =>
-        await BasePlayerQuery(profileId, after, courseId)
+    public async Task<long> GetTotalFramesIn1stByPlayerAsync(long profileId, DateTime? after, short? courseId, short? engineClassId = null) =>
+        await BasePlayerQuery(profileId, after, courseId, engineClassId)
             .SumAsync(r => (long)r.FramesIn1st);
 
     public async Task<(List<RaceResultEntity> Rows, int TotalCount)> GetRecentRacesByPlayerAsync(
-        long profileId, int page, int pageSize, DateTime? after, short? courseId)
+        long profileId, int page, int pageSize, DateTime? after, short? courseId, short? engineClassId = null)
     {
-        var query = BasePlayerQuery(profileId, after, courseId)
+        var query = BasePlayerQuery(profileId, after, courseId, engineClassId)
             .OrderByDescending(r => r.RaceTimestamp);
 
         var totalCount = await query.CountAsync();

--- a/Backend/RetroRewindWebsite/Services/Application/IRaceStatsService.cs
+++ b/Backend/RetroRewindWebsite/Services/Application/IRaceStatsService.cs
@@ -12,6 +12,7 @@ namespace RetroRewindWebsite.Services.Application
             string pid,
             int? days,
             short? courseId,
+            short? engineClassId,
             int page,
             int pageSize);
 

--- a/Backend/RetroRewindWebsite/Services/Application/RaceStatsService.cs
+++ b/Backend/RetroRewindWebsite/Services/Application/RaceStatsService.cs
@@ -34,6 +34,7 @@ public class RaceStatsService : IRaceStatsService
         string pid,
         int? days,
         short? courseId,
+        short? engineClassId,
         int page,
         int pageSize)
     {
@@ -44,7 +45,7 @@ public class RaceStatsService : IRaceStatsService
         var profileId = long.Parse(pid);
         var after = days.HasValue ? DateTime.UtcNow.AddDays(-days.Value) : (DateTime?)null;
 
-        var totalRaces = await _raceStatsRepository.GetTotalRaceCountByPlayerAsync(profileId, after, courseId);
+        var totalRaces = await _raceStatsRepository.GetTotalRaceCountByPlayerAsync(profileId, after, courseId, engineClassId);
         if (totalRaces == 0)
             return null;
 
@@ -52,12 +53,12 @@ public class RaceStatsService : IRaceStatsService
         var trackedSinceTask = StatsQuery(r => r.GetEarliestRaceTimestampAsync());
         var topTracksRawTask = courseId.HasValue
             ? Task.FromResult<List<(short CourseId, int Count)>>([])
-            : StatsQuery(r => r.GetTopTracksByPlayerAsync(profileId, 5, after, courseId));
-        var topCharactersTask = StatsQuery(r => r.GetTopCharactersByPlayerAsync(profileId, TopSetupCount, after, courseId));
-        var topVehiclesTask = StatsQuery(r => r.GetTopVehiclesByPlayerAsync(profileId, TopSetupCount, after, courseId));
-        var topCombosTask = StatsQuery(r => r.GetTopCombosByPlayerAsync(profileId, TopSetupCount, after, courseId));
-        var totalFramesIn1stTask = StatsQuery(r => r.GetTotalFramesIn1stByPlayerAsync(profileId, after, courseId));
-        var recentTask = StatsQuery(r => r.GetRecentRacesByPlayerAsync(profileId, page, pageSize, after, courseId));
+            : StatsQuery(r => r.GetTopTracksByPlayerAsync(profileId, 5, after, courseId, engineClassId));
+        var topCharactersTask = StatsQuery(r => r.GetTopCharactersByPlayerAsync(profileId, TopSetupCount, after, courseId, engineClassId));
+        var topVehiclesTask = StatsQuery(r => r.GetTopVehiclesByPlayerAsync(profileId, TopSetupCount, after, courseId, engineClassId));
+        var topCombosTask = StatsQuery(r => r.GetTopCombosByPlayerAsync(profileId, TopSetupCount, after, courseId, engineClassId));
+        var totalFramesIn1stTask = StatsQuery(r => r.GetTotalFramesIn1stByPlayerAsync(profileId, after, courseId, engineClassId));
+        var recentTask = StatsQuery(r => r.GetRecentRacesByPlayerAsync(profileId, page, pageSize, after, courseId, engineClassId));
 
         await Task.WhenAll(trackedSinceTask, topTracksRawTask, topCharactersTask,
             topVehiclesTask, topCombosTask, totalFramesIn1stTask, recentTask);
@@ -149,7 +150,7 @@ public class RaceStatsService : IRaceStatsService
             return null;
 
         // Race stats are optional, null if player has no race data
-        var raceStats = await GetPlayerRaceStatsAsync(pid, null, null, 1, 20);
+        var raceStats = await GetPlayerRaceStatsAsync(pid, null, null, null, 1, 20);
 
         return RaceStatsMapper.ToPlayerStatsDto(player, raceStats);
     }

--- a/Frontend/src/components/ui/PlayerRaceStatsCard.tsx
+++ b/Frontend/src/components/ui/PlayerRaceStatsCard.tsx
@@ -21,11 +21,13 @@ export default function PlayerRaceStatsCard(props: PlayerRaceStatsCardProps) {
         hasRaceStats,
         days,
         courseId,
+        engineClassId,
         activeTrackName,
         currentPage,
         setCurrentPage,
         handleDaysChange,
         handleCourseIdChange,
+        handleEngineClassChange,
     } = usePlayerRaceStats(props.pid);
 
     const stats = () => raceStatsQuery.data as PlayerRaceStats;
@@ -46,22 +48,47 @@ export default function PlayerRaceStatsCard(props: PlayerRaceStatsCardProps) {
                 <div class="flex items-center gap-2">
                     <h2 class="text-2xl font-bold text-gray-900 dark:text-white">Race Stats</h2>
                 </div>
-                <div class="flex items-center gap-1">
-                    <For each={DAY_OPTIONS}>
-                        {(opt) => (
+                <div class="flex items-center gap-2 flex-wrap justify-end">
+                    {/* CC toggle */}
+                    <div class="flex rounded overflow-hidden border border-gray-200 dark:border-gray-600 text-xs">
+                        {(
+                            [
+                                { label: "All", value: undefined },
+                                { label: "150cc", value: 2 },
+                                { label: "200cc", value: 1 },
+                            ] as const
+                        ).map((opt) => (
                             <button
                                 type="button"
-                                onClick={() => handleDaysChange(opt.value)}
-                                class={`px-3 py-1 rounded text-sm font-medium transition-colors ${
-                                    days() === opt.value
-                                        ? "bg-blue-600 text-white"
-                                        : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+                                onClick={() => handleEngineClassChange(opt.value)}
+                                class={`px-3 py-1.5 font-medium transition-colors ${
+                                    engineClassId() === opt.value
+                                        ? "bg-purple-600 text-white"
+                                        : "bg-white dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600"
                                 }`}
                             >
                                 {opt.label}
                             </button>
-                        )}
-                    </For>
+                        ))}
+                    </div>
+                    {/* Day filter */}
+                    <div class="flex items-center gap-1">
+                        <For each={DAY_OPTIONS}>
+                            {(opt) => (
+                                <button
+                                    type="button"
+                                    onClick={() => handleDaysChange(opt.value)}
+                                    class={`px-3 py-1 rounded text-sm font-medium transition-colors ${
+                                        days() === opt.value
+                                            ? "bg-blue-600 text-white"
+                                            : "bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600"
+                                    }`}
+                                >
+                                    {opt.label}
+                                </button>
+                            )}
+                        </For>
+                    </div>
                 </div>
             </div>
 

--- a/Frontend/src/constants/queryKeys.ts
+++ b/Frontend/src/constants/queryKeys.ts
@@ -19,8 +19,9 @@ export const queryKeys = {
         pid: string | undefined,
         days: number | undefined,
         courseId: number | undefined,
+        engineClassId: number | undefined,
         page: number,
-    ) => ["player-race-stats", pid, days, courseId, page] as const,
+    ) => ["player-race-stats", pid, days, courseId, engineClassId, page] as const,
 
     roomStats: ["roomStatus", "stats"] as const,
     room: (id: number | undefined) => ["roomStatus", id] as const,

--- a/Frontend/src/hooks/usePlayerRaceStats.tsx
+++ b/Frontend/src/hooks/usePlayerRaceStats.tsx
@@ -15,21 +15,30 @@ export function usePlayerRaceStats(pid: string | undefined) {
 
     const [days, setDays] = createSignal<number | undefined>(undefined);
     const [courseId, setCourseId] = createSignal<number | undefined>(undefined);
+    const [engineClassId, setEngineClassId] = createSignal<number | undefined>(undefined);
     const [activeTrackName, setActiveTrackName] = createSignal<string | undefined>(undefined);
 
     // Reset to page 1 when filters change
     createEffect(() => {
         days();
         courseId();
+        engineClassId();
         setCurrentPage(1);
     });
 
     const raceStatsQuery = useQuery(() => ({
-        queryKey: queryKeys.playerRaceStats(pid, days(), courseId(), currentPage()),
+        queryKey: queryKeys.playerRaceStats(
+            pid,
+            days(),
+            courseId(),
+            engineClassId(),
+            currentPage(),
+        ),
         queryFn: () =>
             raceStatsApi.getPlayerRaceStats(pid!, {
                 days: days(),
                 courseId: courseId(),
+                engineClassId: engineClassId(),
                 page: currentPage(),
                 pageSize: PAGE_SIZE,
             }),
@@ -46,15 +55,19 @@ export function usePlayerRaceStats(pid: string | undefined) {
         setActiveTrackName(name);
     };
 
+    const handleEngineClassChange = (value: number | undefined) => setEngineClassId(value);
+
     return {
         raceStatsQuery,
         hasRaceStats,
         days,
         courseId,
+        engineClassId,
         activeTrackName,
         currentPage,
         setCurrentPage,
         handleDaysChange,
         handleCourseIdChange,
+        handleEngineClassChange,
     };
 }

--- a/Frontend/src/services/api/raceStats.ts
+++ b/Frontend/src/services/api/raceStats.ts
@@ -10,6 +10,8 @@ export const raceStatsApi = {
         if (params.days !== undefined) searchParams.append("days", params.days.toString());
         if (params.courseId !== undefined)
             searchParams.append("courseId", params.courseId.toString());
+        if (params.engineClassId !== undefined)
+            searchParams.append("engineClassId", params.engineClassId.toString());
         if (params.page !== undefined) searchParams.append("page", params.page.toString());
         if (params.pageSize !== undefined)
             searchParams.append("pageSize", params.pageSize.toString());

--- a/Frontend/src/types/raceStats.ts
+++ b/Frontend/src/types/raceStats.ts
@@ -67,6 +67,7 @@ export interface GlobalRaceStats {
 export interface PlayerRaceStatsParams {
     days?: number;
     courseId?: number;
+    engineClassId?: number;
     page?: number;
     pageSize?: number;
 }


### PR DESCRIPTION
Introduce an engineClassId (CC) filter across backend and frontend for player race stats. Updated controller, service interface/implementation, and repository methods to accept and apply engineClassId (BasePlayerQuery now filters by EngineClassId). Frontend: added CC toggle UI in PlayerRaceStatsCard, propagated engineClassId through usePlayerRaceStats (state, handlers, query key) and raceStats API call, and updated types/query keys. Also adjusted .gitattributes comment about line ending normalization.

This enables filtering race stats (top tracks/characters/vehicles/combos, totals and recent races) by engine class and ensures the new param is threaded through queries and responses.