### PR TITLE
Update typo on RulesPage.tsx

### DIFF
--- a/Frontend/src/pages/Rules/RulesPage.tsx
+++ b/Frontend/src/pages/Rules/RulesPage.tsx
@@ -150,7 +150,7 @@ export default function RulesPage() {
                         <strong>Allowed:</strong> Stop trolling (coming to a stop with a power item)
                         is allowed as long as it is not being used to troll/target players. Playing
                         like a douchebag is allowed as long as you prioritize actually racing.
-                        Playing with the sole intent to troll/disrupt is unwanted and
+                        Playing with the sole intent to troll/disrupt is unwanted and 
                         <strong>will</strong> result in punishment.
                     </p>
                 </AlertBox>


### PR DESCRIPTION
Fixes a missing space between these words

<img width="871" height="130" alt="image" src="https://github.com/user-attachments/assets/dece761e-7cd1-441b-8c6e-e4252a76e862" />
