### PR TITLE
Add player stats swap endpoint/service

### DIFF
--- a/Backend/Controllers/PlayerModerationController.cs
+++ b/Backend/Controllers/PlayerModerationController.cs
@@ -126,6 +126,39 @@ public class PlayerModerationController : ControllerBase
         }
     }
 
+    [HttpPost("swap")]
+    [ProducesResponseType<SwapResultDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<SwapResultDto>> SwapPlayerStats([FromBody] SwapRequest request)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(request.SourcePid))
+                return BadRequest("Source player ID (SourcePid) is required");
+
+            if (string.IsNullOrWhiteSpace(request.TargetPid))
+                return BadRequest("Target player ID (TargetPid) is required");
+
+            if (request.SourcePid == request.TargetPid)
+                return BadRequest("Source and target PIDs must be different");
+
+            var result = await _moderationService.SwapPlayerStatsAsync(request.SourcePid, request.TargetPid, request.Reason);
+            if (result == null)
+                return NotFound($"One or both players not found (SourcePid: '{request.SourcePid}', TargetPid: '{request.TargetPid}')");
+
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error swapping stats between PID {SourcePid} and PID {TargetPid}",
+                request.SourcePid, request.TargetPid);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                "An error occurred while swapping player stats");
+        }
+    }
+
     // ===== UTILITY ENDPOINTS =====
 
     /// <summary>

--- a/Backend/Models/DTOs/Player/SwapDtos.cs
+++ b/Backend/Models/DTOs/Player/SwapDtos.cs
@@ -1,0 +1,8 @@
+namespace RetroRewindWebsite.Models.DTOs.Player;
+
+public record SwapResultDto(
+    bool Success,
+    string Message,
+    PlayerDto? SourcePlayerAfter = null,
+    PlayerDto? TargetPlayerAfter = null
+);

--- a/Backend/Models/External/SwapRequest.cs
+++ b/Backend/Models/External/SwapRequest.cs
@@ -1,0 +1,9 @@
+namespace RetroRewindWebsite.Models.External;
+
+public class SwapRequest
+{
+    public string SourcePid { get; set; } = string.Empty;
+    public string TargetPid { get; set; } = string.Empty;
+    public string Moderator { get; set; } = string.Empty;
+    public string Reason { get; set; } = string.Empty;
+}

--- a/Backend/Services/Application/IPlayerModerationService.cs
+++ b/Backend/Services/Application/IPlayerModerationService.cs
@@ -39,4 +39,16 @@ public interface IPlayerModerationService
     /// <returns>The result containing the player info and suspicious jump list,
     /// or <see langword="null"/> if no player with the given PID exists.</returns>
     Task<SuspiciousJumpsResultDto?> GetSuspiciousJumpsAsync(string pid);
+
+    /// <summary>
+    /// Atomically swaps all tracked stats between two player licenses: VR, VR history,
+    /// race results, and moderation flags. Neither side loses data — A ends up with B's
+    /// stats and B ends up with A's. Hardware-bound fields (PID, FC, name, Mii) are not touched.
+    /// </summary>
+    /// <param name="sourcePid">The PID of the first player.</param>
+    /// <param name="targetPid">The PID of the second player.</param>
+    /// <param name="reason">The moderator's reason for performing the swap.</param>
+    /// <returns>The result containing both players after the swap,
+    /// or <see langword="null"/> if either PID does not exist.</returns>
+    Task<SwapResultDto?> SwapPlayerStatsAsync(string sourcePid, string targetPid, string reason);
 }

--- a/Backend/Services/Application/PlayerModerationService.cs
+++ b/Backend/Services/Application/PlayerModerationService.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+using RetroRewindWebsite.Data;
 using RetroRewindWebsite.Mappers;
 using RetroRewindWebsite.Models.DTOs.Player;
 using RetroRewindWebsite.Repositories.Player;
@@ -8,6 +10,7 @@ public class PlayerModerationService : IPlayerModerationService
 {
     private readonly IPlayerRepository _playerRepository;
     private readonly IVRHistoryRepository _vrHistoryRepository;
+    private readonly LeaderboardDbContext _context;
     private readonly ILogger<PlayerModerationService> _logger;
 
     private const int SuspiciousJumpThreshold = 529; // Matches PlayerValidationService.MaxVRJumpPerRace
@@ -15,10 +18,12 @@ public class PlayerModerationService : IPlayerModerationService
     public PlayerModerationService(
         IPlayerRepository playerRepository,
         IVRHistoryRepository vrHistoryRepository,
+        LeaderboardDbContext context,
         ILogger<PlayerModerationService> logger)
     {
         _playerRepository = playerRepository;
         _vrHistoryRepository = vrHistoryRepository;
+        _context = context;
         _logger = logger;
     }
 
@@ -130,6 +135,114 @@ public class PlayerModerationService : IPlayerModerationService
             PlayerMapper.ToBasicDto(player),
             suspiciousJumps,
             suspiciousJumps.Count
+        );
+    }
+
+    public async Task<SwapResultDto?> SwapPlayerStatsAsync(string sourcePid, string targetPid, string reason)
+    {
+        // Load both players with tracking so SaveChangesAsync picks up changes
+        var source = await _context.Players.FirstOrDefaultAsync(p => p.Pid == sourcePid);
+        if (source == null)
+            return null;
+
+        var target = await _context.Players.FirstOrDefaultAsync(p => p.Pid == targetPid);
+        if (target == null)
+            return null;
+
+        await using var transaction = await _context.Database.BeginTransactionAsync();
+        try
+        {
+            // --- Capture source stats before overwriting ---
+            var srcEv = source.Ev;
+            var srcGain24h = source.VRGainLast24Hours;
+            var srcGainWeek = source.VRGainLastWeek;
+            var srcGainMonth = source.VRGainLastMonth;
+            var srcIsSuspicious = source.IsSuspicious;
+            var srcSuspiciousVRJumps = source.SuspiciousVRJumps;
+            var srcFlagReason = source.FlagReason;
+            var srcUnflagReason = source.UnflagReason;
+            var srcIsBanned = source.IsBanned;
+
+            // --- Write target's stats onto source ---
+            source.Ev = target.Ev;
+            source.VRGainLast24Hours = target.VRGainLast24Hours;
+            source.VRGainLastWeek = target.VRGainLastWeek;
+            source.VRGainLastMonth = target.VRGainLastMonth;
+            source.IsSuspicious = target.IsSuspicious;
+            source.SuspiciousVRJumps = target.SuspiciousVRJumps;
+            source.FlagReason = target.FlagReason;
+            source.UnflagReason = target.UnflagReason;
+            source.IsBanned = target.IsBanned;
+
+            // --- Write source's saved stats onto target ---
+            target.Ev = srcEv;
+            target.VRGainLast24Hours = srcGain24h;
+            target.VRGainLastWeek = srcGainWeek;
+            target.VRGainLastMonth = srcGainMonth;
+            target.IsSuspicious = srcIsSuspicious;
+            target.SuspiciousVRJumps = srcSuspiciousVRJumps;
+            target.FlagReason = srcFlagReason;
+            target.UnflagReason = srcUnflagReason;
+            target.IsBanned = srcIsBanned;
+
+            // --- Swap VR history records ---
+            // Both PIDs exist in the Players table throughout this transaction, so neither
+            // FK update violates a constraint. Source records go to target, target records go to source.
+            await _context.VRHistories
+                .Where(v => v.PlayerId == sourcePid)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(v => v.PlayerId, targetPid)
+                    .SetProperty(v => v.Fc, target.Fc));
+
+            await _context.VRHistories
+                .Where(v => v.PlayerId == targetPid)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(v => v.PlayerId, sourcePid)
+                    .SetProperty(v => v.Fc, source.Fc));
+
+            // --- Swap race result records ---
+            // ProfileId is the numeric form of the PID (long). PlayerId is the PlayerEntity int PK.
+            var sourceProfileId = long.Parse(sourcePid);
+            var targetProfileId = long.Parse(targetPid);
+
+            await _context.RaceResults
+                .Where(r => r.ProfileId == sourceProfileId)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(r => r.ProfileId, targetProfileId)
+                    .SetProperty(r => r.PlayerId, target.Id));
+
+            await _context.RaceResults
+                .Where(r => r.ProfileId == targetProfileId)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(r => r.ProfileId, sourceProfileId)
+                    .SetProperty(r => r.PlayerId, source.Id));
+
+            // --- Flush player entity changes and commit ---
+            await _context.SaveChangesAsync();
+            await transaction.CommitAsync();
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+
+        // Ranks depend on Ev, so recalculate after the swap
+        await _playerRepository.UpdatePlayerRanksAsync();
+
+        _logger.LogWarning(
+            "Player stats swapped: {SourceName} ({SourcePid}) <-> {TargetName} ({TargetPid}) - Reason: {Reason}",
+            source.Name, sourcePid, target.Name, targetPid, reason);
+
+        // Re-fetch for accurate post-swap state (including updated rank)
+        var sourceAfter = await _playerRepository.GetByPidAsync(sourcePid);
+        var targetAfter = await _playerRepository.GetByPidAsync(targetPid);
+
+        return new SwapResultDto(
+            true,
+            $"Stats swapped between '{source.Name}' ({sourcePid}) and '{target.Name}' ({targetPid}). Reason: '{reason}'",
+            sourceAfter != null ? PlayerMapper.ToDto(sourceAfter) : null,
+            targetAfter != null ? PlayerMapper.ToDto(targetAfter) : null
         );
     }
 }


### PR DESCRIPTION
Introduce an administrative swap feature to atomically exchange tracked player stats between two PIDs. Adds POST /swap in PlayerModerationController with input validation and error responses, new SwapRequest and SwapResultDto DTOs, and a SwapPlayerStatsAsync contract to IPlayerModerationService. PlayerModerationService now depends on LeaderboardDbContext and implements the swap inside a DB transaction: it swaps player stat fields, updates VRHistory and RaceResult records via ExecuteUpdateAsync (swapping PlayerId/ProfileId and Fc), saves changes, recalculates ranks, logs the action, and returns the post-swap player DTOs. Hardware-bound fields (PID/FC/name/Mii) are preserved and the method returns null if either PID is missing.