### PR TITLE
Change update url to update.rwfc.net

### DIFF
--- a/Frontend/src/pages/Downloads/DownloadsPage.tsx
+++ b/Frontend/src/pages/Downloads/DownloadsPage.tsx
@@ -132,7 +132,7 @@ export default function DownloadsPage() {
                 </p>
                 <div class="flex flex-col sm:flex-row gap-3">
                     <a
-                        href="https://rwfc.net/updates/RetroRewind/zip/RetroRewind.zip"
+                        href="https://update.rwfc.net/RetroRewind/zip/RetroRewind.zip"
                         target="_blank"
                         rel="noopener noreferrer"
                         class="bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-6 rounded-lg transition-colors text-center"

--- a/Frontend/src/services/api/leaderboard.ts
+++ b/Frontend/src/services/api/leaderboard.ts
@@ -91,7 +91,7 @@ export const leaderboardApi = {
     async getRRVersion() {
         try {
             const response = await fetch(
-                "https://rwfc.net/updates/RetroRewind/RetroRewindVersion.txt",
+                "https://update.rwfc.net/RetroRewind/RetroRewindVersion.txt",
             );
 
             if (!response.ok) {
@@ -105,7 +105,7 @@ export const leaderboardApi = {
 
             const updateUrl = latest[1].replace(
                 "http://update.rwfc.net:8000/RetroRewind",
-                "https://rwfc.net/updates/RetroRewind",
+                "https://update.rwfc.net/RetroRewind",
             );
 
             return {


### PR DESCRIPTION
See title. This does not work in dev due to CORS issues, however upon deployment I have configured nginx to adjust the CORS headers. If there is a way to do that in our backend I am unaware, however we should use it if a way exists.

It may be desirable to make the update URL a variable instead of hardcoding it, but I don't anticipate ever needing to change this.