### PR TITLE
Add badges to players

### DIFF
--- a/Backend/Controllers/BadgeController.cs
+++ b/Backend/Controllers/BadgeController.cs
@@ -18,26 +18,23 @@ public class BadgeController : ControllerBase
         _logger = logger;
     }
 
-    [HttpPost("by_pid")]
+    [HttpGet("by_pid/{pid}")]
     [ProducesResponseType<BadgeDto>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<BadgeDto>> BadgesByPid([FromBody] BadgeRequest request)
+    public async Task<ActionResult<BadgeDto>> BadgesByPid(string pid)
     {
         try
         {
-            if (string.IsNullOrWhiteSpace(request.Pid))
-                return BadRequest("Player ID (Pid) is required");
-
-            var player = await _playerRepository.GetByPidAsync(request.Pid);
+            var player = await _playerRepository.GetByPidAsync(pid);
             if (player == null)
-                return NotFound($"Player with PID '${request.Pid}' not found");
+                return NotFound($"Player with PID '${pid}' not found");
 
             return Ok(new BadgeDto(player.Badges ?? []));
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error querying badges for player with PID {Pid}", request.Pid);
+            _logger.LogError(ex, "Error querying badges for player with PID {Pid}", pid);
             return StatusCode(StatusCodes.Status500InternalServerError,
                 "An error occurred while querying the player");
         }

--- a/Backend/Controllers/BadgeController.cs
+++ b/Backend/Controllers/BadgeController.cs
@@ -1,0 +1,73 @@
+using Microsoft.AspNetCore.Mvc;
+using RetroRewindWebsite.Models.DTOs.Player;
+using RetroRewindWebsite.Models.External;
+using RetroRewindWebsite.Repositories.Player;
+
+namespace RetroRewindWebsite.Controllers;
+
+[ApiController]
+[Route("api/badges")]
+public class BadgeController : ControllerBase
+{
+    private readonly IPlayerRepository _playerRepository;
+    private readonly ILogger<BadgeController> _logger;
+
+    public BadgeController(IPlayerRepository playerRepository, ILogger<BadgeController> logger)
+    {
+        _playerRepository = playerRepository;
+        _logger = logger;
+    }
+
+    [HttpPost("by_pid")]
+    [ProducesResponseType<BadgeDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<BadgeDto>> BadgesByPid([FromBody] BadgeRequest request)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(request.Pid))
+                return BadRequest("Player ID (Pid) is required");
+
+            var player = await _playerRepository.GetByPidAsync(request.Pid);
+            if (player == null)
+                return NotFound($"Player with PID '${request.Pid}' not found");
+
+            return Ok(new BadgeDto(player.Badges ?? []));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error querying badges for player with PID {Pid}", request.Pid);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                "An error occurred while querying the player");
+        }
+    }
+
+    [HttpPost("by_pids")]
+    [ProducesResponseType<BatchBadgeDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<BatchBadgeDto>> BadgesByPids([FromBody] BatchBadgeRequest request)
+    {
+        try
+        {
+            if (request.Pids == null || request.Pids.Count == 0)
+                return BadRequest("Player IDs (Pids) are required");
+
+            var players = await _playerRepository.GetPlayersByPidsAsync(request.Pids);
+            var badgeMap = new Dictionary<string, ICollection<int>>();
+
+            foreach (var player in players)
+                badgeMap.Add(player.Pid, player.Badges ?? []);
+
+            return Ok(new BatchBadgeDto(badgeMap));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error querying badges for players with PIDs {Pids}", request.Pids);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                "An error occurred while querying the players");
+        }
+
+    }
+}

--- a/Backend/Controllers/BadgeController.cs
+++ b/Backend/Controllers/BadgeController.cs
@@ -68,6 +68,23 @@ public class BadgeController : ControllerBase
             return StatusCode(StatusCodes.Status500InternalServerError,
                 "An error occurred while querying the players");
         }
+    }
 
+    [HttpGet("all")]
+    [ProducesResponseType<BatchBadgeDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<BatchBadgeDto>> AllBadges()
+    {
+        try
+        {
+            var badges = await _playerRepository.GetAllBadgedPlayersAsync();
+            return Ok(new BatchBadgeDto(badges));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error querying all badged players");
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                "An error occurred while querying the badges");
+        }
     }
 }

--- a/Backend/Controllers/PlayerModerationController.cs
+++ b/Backend/Controllers/PlayerModerationController.cs
@@ -174,4 +174,56 @@ public class PlayerModerationController : ControllerBase
 
         return Ok(new CountryListResultDto(true, countries.Count, countries));
     }
+
+    [HttpPost("badges/add")]
+    [ProducesResponseType<ModerationActionResultDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<ModerationActionResultDto>> AddBadge([FromBody] BadgeManagementRequest request)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(request.Pid))
+                return BadRequest("A player ID (PID) is required");
+
+            var result = await _moderationService.AddBadgeAsync(request.Pid, request.Badge);
+            if (result == null)
+                return NotFound($"Player with pid '{request.Pid}' not found");
+
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error removing badge from player with pid {Pid}", request.Pid);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                "An error occurred while adding a badge to the player");
+        }
+    }
+
+    [HttpPost("badges/remove")]
+    [ProducesResponseType<ModerationActionResultDto>(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<ActionResult<ModerationActionResultDto>> RemoveBadge([FromBody] BadgeManagementRequest request)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(request.Pid))
+                return BadRequest("A player ID (PID) is required");
+
+            var result = await _moderationService.RemoveBadgeAsync(request.Pid, request.Badge);
+            if (result == null)
+                return NotFound($"Player with pid '{request.Pid}' not found");
+
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error removing badge from player with pid {Pid}", request.Pid);
+            return StatusCode(StatusCodes.Status500InternalServerError,
+                "An error occurred while removing a badge from the player");
+        }
+    }
 }

--- a/Backend/Controllers/PlayerModerationController.cs
+++ b/Backend/Controllers/PlayerModerationController.cs
@@ -180,7 +180,7 @@ public class PlayerModerationController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<ModerationActionResultDto>> AddBadge([FromBody] BadgeManagementRequest request)
+    public async Task<ActionResult<BadgeModerationActionResultDto>> AddBadge([FromBody] BadgeManagementRequest request)
     {
         try
         {
@@ -206,7 +206,7 @@ public class PlayerModerationController : ControllerBase
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-    public async Task<ActionResult<ModerationActionResultDto>> RemoveBadge([FromBody] BadgeManagementRequest request)
+    public async Task<ActionResult<BadgeModerationActionResultDto>> RemoveBadge([FromBody] BadgeManagementRequest request)
     {
         try
         {

--- a/Backend/Mappers/PlayerMapper.cs
+++ b/Backend/Mappers/PlayerMapper.cs
@@ -21,7 +21,8 @@ public static class PlayerMapper
             entity.VRGainLastWeek,
             entity.VRGainLastMonth),
         MiiImageBase64: entity.MiiCache?.MiiImageBase64,
-        MiiData: entity.MiiData
+        MiiData: entity.MiiData,
+        Badges: entity.Badges
     );
 
     /// <summary>
@@ -40,7 +41,8 @@ public static class PlayerMapper
             entity.VRGainLastWeek,
             entity.VRGainLastMonth),
         MiiImageBase64: null,
-        MiiData: entity.MiiData
+        MiiData: entity.MiiData,
+        Badges: entity.Badges
     );
 
     /// <summary>
@@ -57,7 +59,8 @@ public static class PlayerMapper
         IsSuspicious: entity.IsSuspicious,
         VRStats: new VRStatsDto(0, 0, 0),
         MiiImageBase64: entity.MiiImageBase64,
-        MiiData: entity.MiiData
+        MiiData: entity.MiiData,
+        Badges: null
     );
 
     /// <summary>

--- a/Backend/Mappers/RaceStatsMapper.cs
+++ b/Backend/Mappers/RaceStatsMapper.cs
@@ -31,7 +31,8 @@ public static class RaceStatsMapper
         VrGain24h: player.VRGainLast24Hours,
         VrGain7d: player.VRGainLastWeek,
         VrGain30d: player.VRGainLastMonth,
-        RaceStats: raceStats
+        RaceStats: raceStats,
+        Badges: player.Badges
     );
 
     /// <summary>

--- a/Backend/Migrations/20260718082723_AddPlayerBadges.Designer.cs
+++ b/Backend/Migrations/20260718082723_AddPlayerBadges.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using RetroRewindWebsite.Data;
@@ -13,9 +14,11 @@ using RetroRewindWebsite.Models.Entities.Room;
 namespace RetroRewindWebsite.Migrations
 {
     [DbContext(typeof(LeaderboardDbContext))]
-    partial class LeaderboardDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260718082723_AddPlayerBadges")]
+    partial class AddPlayerBadges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/Migrations/20260718082723_AddPlayerBadges.cs
+++ b/Backend/Migrations/20260718082723_AddPlayerBadges.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace RetroRewindWebsite.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPlayerBadges : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int[]>(
+                name: "Badges",
+                table: "Players",
+                type: "integer[]",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Badges",
+                table: "Players");
+        }
+    }
+}

--- a/Backend/Models/DTOs/Player/BadgeDto.cs
+++ b/Backend/Models/DTOs/Player/BadgeDto.cs
@@ -1,0 +1,9 @@
+namespace RetroRewindWebsite.Models.DTOs.Player;
+
+public record BadgeDto(
+    ICollection<int> Badges
+);
+
+public record BatchBadgeDto(
+    Dictionary<string, ICollection<int>> Badges
+);

--- a/Backend/Models/DTOs/Player/ModerationDtos.cs
+++ b/Backend/Models/DTOs/Player/ModerationDtos.cs
@@ -9,3 +9,5 @@ public record SuspiciousJumpsResultDto(
 );
 
 public record ModerationActionResultDto(bool Success, string Message, PlayerDto? Player = null);
+
+public record BadgeModerationActionResultDto(bool Success, string Message, ICollection<int> Badges);

--- a/Backend/Models/DTOs/Player/PlayerDto.cs
+++ b/Backend/Models/DTOs/Player/PlayerDto.cs
@@ -10,7 +10,8 @@ public record PlayerDto(
     bool IsSuspicious,
     VRStatsDto VRStats,
     string? MiiImageBase64,
-    string? MiiData
+    string? MiiData,
+    ICollection<int>? Badges
 );
 
 public record PlayerMiiDownloadDto(string Name, string? MiiData);

--- a/Backend/Models/DTOs/RaceStats/PlayerStats.cs
+++ b/Backend/Models/DTOs/RaceStats/PlayerStats.cs
@@ -12,5 +12,6 @@ public record PlayerStatsDto(
     int VrGain7d,
     int VrGain30d,
 
-    PlayerRaceStatsDto? RaceStats
+    PlayerRaceStatsDto? RaceStats,
+    ICollection<int>? Badges
 );

--- a/Backend/Models/Entities/Player/PlayerEntity.cs
+++ b/Backend/Models/Entities/Player/PlayerEntity.cs
@@ -32,4 +32,6 @@ public class PlayerEntity
 
     public virtual PlayerMiiCacheEntity? MiiCache { get; set; }
     public virtual ICollection<VRHistoryEntity> VRHistory { get; set; } = [];
+
+    public ICollection<int>? Badges { get; set; }
 }

--- a/Backend/Models/External/BadgeRequest.cs
+++ b/Backend/Models/External/BadgeRequest.cs
@@ -1,0 +1,17 @@
+namespace RetroRewindWebsite.Models.External;
+
+public class BadgeRequest
+{
+    public string Pid { get; set; } = string.Empty;
+}
+
+public class BatchBadgeRequest
+{
+    public required List<string> Pids { get; set; }
+}
+
+public class BadgeManagementRequest
+{
+    public string Pid { get; set; } = string.Empty;
+    public int Badge; // The badge to add or remove
+}

--- a/Backend/Models/External/BadgeRequest.cs
+++ b/Backend/Models/External/BadgeRequest.cs
@@ -13,5 +13,5 @@ public class BatchBadgeRequest
 public class BadgeManagementRequest
 {
     public string Pid { get; set; } = string.Empty;
-    public int Badge; // The badge to add or remove
+    public int Badge { get; set; } // The badge to add or remove
 }

--- a/Backend/Repositories/Player/IPlayerRepository.cs
+++ b/Backend/Repositories/Player/IPlayerRepository.cs
@@ -132,5 +132,4 @@ public interface IPlayerRepository
     /// Updates multiple player entities in a single database round-trip.
     /// </summary>
     Task UpdateRangeAsync(IEnumerable<PlayerEntity> players);
-
 }

--- a/Backend/Repositories/Player/IPlayerRepository.cs
+++ b/Backend/Repositories/Player/IPlayerRepository.cs
@@ -116,6 +116,11 @@ public interface IPlayerRepository
     Task<List<string>> GetPlayerPidsBatchAsync(int skip, int take);
 
     /// <summary>
+    /// Retrieves every player with badges. Returned as a dictionary of pids to badges.
+    /// </summary>
+    Task<Dictionary<string, ICollection<int>>> GetAllBadgedPlayersAsync();
+
+    /// <summary>
     /// Updates the VR gains for multiple players asynchronously in batch.
     /// </summary>
     /// <param name="vrGains">A dictionary containing player identifiers as keys and tuples representing VR gains for 24 hours, 7 days, and 30

--- a/Backend/Repositories/Player/PlayerRepository.cs
+++ b/Backend/Repositories/Player/PlayerRepository.cs
@@ -177,6 +177,14 @@ public class PlayerRepository : IPlayerRepository, IPlayerMiiRepository, ILegacy
             .Select(p => p.Pid)
             .ToListAsync();
 
+    public async Task<Dictionary<string, ICollection<int>>> GetAllBadgedPlayersAsync() =>
+        await _context.Players
+            .AsNoTracking()
+            .OrderBy(p => p.Id)
+            .Where(p => p.Badges != null && p.Badges.Count > 0)
+            .Select(p => new { p.Pid, p.Badges })
+            .ToDictionaryAsync(p => p.Pid, p => p.Badges!);
+
     public async Task UpdatePlayerVRGainsBatchAsync(
         Dictionary<string, (int gain24h, int gain7d, int gain30d)> vrGains)
     {

--- a/Backend/Repositories/Player/PlayerRepository.cs
+++ b/Backend/Repositories/Player/PlayerRepository.cs
@@ -207,7 +207,7 @@ public class PlayerRepository : IPlayerRepository, IPlayerMiiRepository, ILegacy
 
             await _context.Database.ExecuteSqlRawAsync(@"
                 UPDATE ""Players"" p
-                SET 
+                SET
                     ""VRGainLast24Hours"" = t.gain24h,
                     ""VRGainLastWeek"" = t.gain7d,
                     ""VRGainLastMonth"" = t.gain30d

--- a/Backend/Services/Application/IPlayerModerationService.cs
+++ b/Backend/Services/Application/IPlayerModerationService.cs
@@ -52,7 +52,7 @@ public interface IPlayerModerationService
     /// or <see langword="null"/> if either PID does not exist.</returns>
     Task<SwapResultDto?> SwapPlayerStatsAsync(string sourcePid, string targetPid, string reason);
 
-    Task<ModerationActionResultDto?> AddBadgeAsync(string pid, int badge);
+    Task<BadgeModerationActionResultDto?> AddBadgeAsync(string pid, int badge);
 
-    Task<ModerationActionResultDto?> RemoveBadgeAsync(string pid, int badge);
+    Task<BadgeModerationActionResultDto?> RemoveBadgeAsync(string pid, int badge);
 }

--- a/Backend/Services/Application/IPlayerModerationService.cs
+++ b/Backend/Services/Application/IPlayerModerationService.cs
@@ -51,4 +51,8 @@ public interface IPlayerModerationService
     /// <returns>The result containing both players after the swap,
     /// or <see langword="null"/> if either PID does not exist.</returns>
     Task<SwapResultDto?> SwapPlayerStatsAsync(string sourcePid, string targetPid, string reason);
+
+    Task<ModerationActionResultDto?> AddBadgeAsync(string pid, int badge);
+
+    Task<ModerationActionResultDto?> RemoveBadgeAsync(string pid, int badge);
 }

--- a/Backend/Services/Application/PlayerModerationService.cs
+++ b/Backend/Services/Application/PlayerModerationService.cs
@@ -248,4 +248,61 @@ public class PlayerModerationService : IPlayerModerationService
             targetAfter != null ? PlayerMapper.ToDto(targetAfter) : null
         );
     }
+
+    public async Task<ModerationActionResultDto?> AddBadgeAsync(string pid, int badge)
+    {
+        var player = await _playerRepository.GetByPidAsync(pid);
+        if (player == null)
+            return null;
+
+        player.Badges ??= [];
+
+        if (player.Badges.Contains(badge))
+        {
+            return new ModerationActionResultDto(
+                false,
+                $"Player '${player.Name}' already has this badge"
+            );
+        }
+
+        player.Badges.Add(badge);
+        await _playerRepository.UpdateAsync(player);
+
+        _logger.LogWarning(
+            "Badge added to player: {Name} ({FriendCode}) - PID: {Pid} - Badge: {Badge}",
+            player.Name, player.Fc, player.Pid);
+
+        return new ModerationActionResultDto(
+            true,
+            $"Player '${player.Name}' has been given a badge",
+            PlayerMapper.ToDto(player)
+        );
+    }
+
+    public async Task<ModerationActionResultDto?> RemoveBadgeAsync(string pid, int badge)
+    {
+        var player = await _playerRepository.GetByPidAsync(pid);
+        if (player == null)
+            return null;
+
+        if (player.Badges == null || player.Badges.Count == 0 || !player.Badges.Contains(badge))
+        {
+            return new ModerationActionResultDto(
+                false,
+                $"Player '{player.Name}' does not have this badge"
+            );
+        }
+
+        player.Badges.Remove(badge);
+
+        _logger.LogWarning(
+            "Badge removed from player: {Name} ({FriendCode}) - PID: {Pid} - Badge: {Badge}",
+            player.Name, player.Fc, player.Pid, badge);
+
+        return new ModerationActionResultDto(
+            true,
+            $"Player '${player.Name}' has had a badge removed",
+            PlayerMapper.ToDto(player)
+        );
+    }
 }

--- a/Backend/Services/Application/PlayerModerationService.cs
+++ b/Backend/Services/Application/PlayerModerationService.cs
@@ -294,6 +294,7 @@ public class PlayerModerationService : IPlayerModerationService
         }
 
         player.Badges.Remove(badge);
+        await _playerRepository.UpdateAsync(player);
 
         _logger.LogWarning(
             "Badge removed from player: {Name} ({FriendCode}) - PID: {Pid} - Badge: {Badge}",

--- a/Backend/Services/Application/PlayerModerationService.cs
+++ b/Backend/Services/Application/PlayerModerationService.cs
@@ -249,7 +249,7 @@ public class PlayerModerationService : IPlayerModerationService
         );
     }
 
-    public async Task<ModerationActionResultDto?> AddBadgeAsync(string pid, int badge)
+    public async Task<BadgeModerationActionResultDto?> AddBadgeAsync(string pid, int badge)
     {
         var player = await _playerRepository.GetByPidAsync(pid);
         if (player == null)
@@ -259,9 +259,10 @@ public class PlayerModerationService : IPlayerModerationService
 
         if (player.Badges.Contains(badge))
         {
-            return new ModerationActionResultDto(
+            return new BadgeModerationActionResultDto(
                 false,
-                $"Player '${player.Name}' already has this badge"
+                $"Player '${player.Name}' already has this badge",
+                player.Badges
             );
         }
 
@@ -272,14 +273,14 @@ public class PlayerModerationService : IPlayerModerationService
             "Badge added to player: {Name} ({FriendCode}) - PID: {Pid} - Badge: {Badge}",
             player.Name, player.Fc, player.Pid);
 
-        return new ModerationActionResultDto(
+        return new BadgeModerationActionResultDto(
             true,
             $"Player '${player.Name}' has been given a badge",
-            PlayerMapper.ToDto(player)
+            player.Badges
         );
     }
 
-    public async Task<ModerationActionResultDto?> RemoveBadgeAsync(string pid, int badge)
+    public async Task<BadgeModerationActionResultDto?> RemoveBadgeAsync(string pid, int badge)
     {
         var player = await _playerRepository.GetByPidAsync(pid);
         if (player == null)
@@ -287,9 +288,10 @@ public class PlayerModerationService : IPlayerModerationService
 
         if (player.Badges == null || player.Badges.Count == 0 || !player.Badges.Contains(badge))
         {
-            return new ModerationActionResultDto(
+            return new BadgeModerationActionResultDto(
                 false,
-                $"Player '{player.Name}' does not have this badge"
+                $"Player '{player.Name}' does not have this badge",
+                player.Badges ?? []
             );
         }
 
@@ -300,10 +302,10 @@ public class PlayerModerationService : IPlayerModerationService
             "Badge removed from player: {Name} ({FriendCode}) - PID: {Pid} - Badge: {Badge}",
             player.Name, player.Fc, player.Pid, badge);
 
-        return new ModerationActionResultDto(
+        return new BadgeModerationActionResultDto(
             true,
             $"Player '${player.Name}' has had a badge removed",
-            PlayerMapper.ToDto(player)
+            player.Badges
         );
     }
 }


### PR DESCRIPTION
Stores badges as a new field for each player. These are just integers which should be interpreted consistently by clients.

Exposes `/api/badges/by_pid` and `/api/badges/by_pids` as public endpoints which allow one to query the badges of a player or multiple players respectively.

Exposes `/api/moderation/badges/add` and `/api/moderation/badges/remove` as private endpoints which allow moderators to grant and revoke badges.

This is a draft PR for now until I finish the relevant parts of the bot and have a chance to test everything out.